### PR TITLE
 Avoid crashing node due to post-setup connection errors

### DIFF
--- a/src/adb/client.coffee
+++ b/src/adb/client.coffee
@@ -63,16 +63,7 @@ class Client
     new TcpUsbServer this, serial, options
 
   connection: ->
-    resolver = Promise.defer()
-    conn = new Connection(@options)
-      .on 'error', errorListener = (err) ->
-        resolver.reject err
-      .on 'connect', connectListener = ->
-        resolver.resolve conn
-      .connect()
-    resolver.promise.finally ->
-      conn.removeListener 'error', errorListener
-      conn.removeListener 'connect', connectListener
+    new Connection(@options).connect()
 
   version: (callback) ->
     this.connection()

--- a/src/adb/client.coffee
+++ b/src/adb/client.coffee
@@ -1,6 +1,7 @@
 Monkey = require '@devicefarmer/adbkit-monkey'
 Logcat = require '@devicefarmer/adbkit-logcat'
 Promise = require 'bluebird'
+{EventEmitter} = require 'events'
 debug = require('debug')('adb:client')
 
 Connection = require './connection'
@@ -54,7 +55,7 @@ WaitForDeviceCommand = require './command/host-serial/waitfordevice'
 
 TcpUsbServer = require './tcpusb/server'
 
-class Client
+class Client extends EventEmitter
   constructor: (@options = {}) ->
     @options.port ||= 5037
     @options.bin ||= 'adb'
@@ -63,7 +64,13 @@ class Client
     new TcpUsbServer this, serial, options
 
   connection: ->
-    new Connection(@options).connect()
+    connection = new Connection(@options)
+
+    # Reemit unhandled connection errors, so they can be handled externally.
+    # If not handled at all, these will crash node.
+    connection.on('error', (err) => this.emit('error', err))
+
+    return connection.connect()
 
   version: (callback) ->
     this.connection()

--- a/src/adb/connection.coffee
+++ b/src/adb/connection.coffee
@@ -1,4 +1,5 @@
 Net = require 'net'
+Promise = require 'bluebird'
 debug = require('debug')('adb:connection')
 {EventEmitter} = require 'events'
 {execFile} = require 'child_process'
@@ -24,11 +25,27 @@ class Connection extends EventEmitter
       this.emit 'drain'
     @socket.on 'timeout', =>
       this.emit 'timeout'
-    @socket.on 'error', (err) =>
-      this._handleError err
+    @socket.on 'error', (err) ->
+      # We log but ignore all socket errors. These are also listened to
+      # by parser though during all send/receive operations, and will
+      # trigger errors there, if there's anything in progress.
+      debug "ADB connection error: #{err.message}"
     @socket.on 'close', (hadError) =>
       this.emit 'close', hadError
-    return this
+
+    return new Promise (resolve, reject) =>
+      @socket.once 'connect', resolve
+      @socket.once 'error', reject
+    .catch (err) =>
+      if err.code is 'ECONNREFUSED' and not @triedStarting
+        debug "Connection was refused, let's try starting the server once"
+        @triedStarting = true
+        return this.startServer().then =>
+          this.connect()
+      else
+        this.end()
+        throw err
+    .then => this
 
   end: ->
     @socket.end()
@@ -38,28 +55,17 @@ class Connection extends EventEmitter
     @socket.write dump(data), callback
     return this
 
-  startServer: (callback) ->
+  startServer: () ->
     port = @options.port
     args = if port then ['-P', port, 'start-server'] else ['start-server']
     debug "Starting ADB server via '#{@options.bin} #{args.join ' '}'"
-    return this._exec args, {}, callback
+    return this._exec args, {}
 
-  _exec: (args, options, callback) ->
+  _exec: (args, options) ->
     debug "CLI: #{@options.bin} #{args.join ' '}"
-    execFile @options.bin, args, options, callback
-    return this
+    return Promise.promisify(execFile)(@options.bin, args, options)
 
   _handleError: (err) ->
-    if err.code is 'ECONNREFUSED' and not @triedStarting
-      debug "Connection was refused, let's try starting the server once"
-      @triedStarting = true
-      this.startServer (err) =>
-        return this._handleError err if err
-        this.connect()
-    else
-      debug "Connection had an error: #{err.message}"
-      this.emit 'error', err
-      this.end()
     return
 
 module.exports = Connection

--- a/src/adb/sync.coffee
+++ b/src/adb/sync.coffee
@@ -147,10 +147,16 @@ class Sync extends EventEmitter
       stream.on 'error', errorListener = (err) ->
         resolver.reject err
 
-      resolver.promise.finally ->
+      @connection.on 'error', connErrorListener = (err) =>
+        stream.destroy(err)
+        @connection.end()
+        resolver.reject err
+
+      resolver.promise.finally =>
         stream.removeListener 'end', endListener
         stream.removeListener 'readable', readableListener
         stream.removeListener 'error', errorListener
+        @connection.removeListener 'error', connErrorListener
         writer.cancel()
 
     readReply = =>

--- a/test/mock/connection.coffee
+++ b/test/mock/connection.coffee
@@ -14,4 +14,6 @@ class MockConnection
     @socket.write.apply @socket, arguments
     return this
 
+  on: ->
+
 module.exports = MockConnection


### PR DESCRIPTION
_Migrated from https://github.com/openstf/adbkit/pull/131_

Newly setup connections have an error handler for errors during setup. Unfortunately, once initial connection is complete, this is removed.

Subsequent code listens to errors on the socket, but not on the connection object, which re-emits the socket's errors. That means if any 'error' events are fired on the ADB socket after initial setup, the entire node process crashes.

There's a few ways that this can manifest, but the easiest is any disconnection from ADB whilst an operation is in process.

On linux you can test this using tcpkill: sudo tcpkill -i lo -9 dst port 5037. This tries to aggressively inject RST packets into all active localhost:5037 connections. If you run this, and then try to do any non-trivial ADB process with adbkit, your node process will crash immediately. That's not great!

I'm hitting this in my own app (HTTP Toolkit), which uses adbkit under the hood. This PR solves it nicely, by:

    Stopping Connection from emitting errors unless the socket has no other error handlers
    Making errors that are emitted from Connection be re-emitted on the Client, so they can be handled there by downstream code with client.on('error', ...).

I also noticed en route that the Sync command doesn't do any error checking on the ADB socket at all, that's now fixed (by the 2nd commit here).