### PR TITLE
Always provide js version of library from index.coffee

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -1,5 +1,1 @@
-Path = require 'path'
-
-module.exports = switch Path.extname __filename
-  when '.coffee' then require './src/adb'
-  else require './lib/adb'
+module.exports = require './lib/adb'


### PR DESCRIPTION
Fixes #16 

NPM only distributes the transpiled JavaScript version of this library anyway, so there shouldn't be any danger in removing this check.

