### PR TITLE
Update node-forge

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "bluebird": "~2.9.24",
     "commander": "^2.3.0",
     "debug": "~2.6.3",
-    "node-forge": "^0.7.1",
+    "node-forge": "^0.9.1",
     "split": "~0.3.3"
   },
   "devDependencies": {

--- a/src/adb/tcpusb/socket.coffee
+++ b/src/adb/tcpusb/socket.coffee
@@ -2,7 +2,6 @@ crypto = require 'crypto'
 {EventEmitter} = require 'events'
 
 Promise = require 'bluebird'
-Forge = require 'node-forge'
 debug = require('debug')('adb:tcpusb:socket')
 
 Parser = require '../parser'


### PR DESCRIPTION
It'd be useful to update node-forge because:

* It now uses the native Node & web crypto APIs, when available, not just its own pure JS implementations, which makes everything _dramatically_ faster (about 15x faster, in my application).
* It removes all internal uses of `new Buffer`, which is [deprecated as unsafe in node](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/), and prints annoying warnings. There's still other instances of this in adbkit, but this a good step in the right direction anyway.
* For users (like me) who are using both node-forge and adbkit themselves, it's useful to have the latest version, to avoid duplicating the whole lib in their app, as it's a pretty heavy library.

This also drops the reference to it in `socket.coffee`, because it's not used there at all.

I've read through [their changelog](https://github.com/digitalbazaar/forge/blob/master/CHANGELOG.md), there's no relevant breaking changes listed in there. The tests here all still seem to pass, and adbkit continues working great in my app.