### PR TITLE
add flag argument to client.getPackages

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,24 @@ Retrieves the list of packages present on the device. This is analogous to `adb 
 * Returns: `Promise`
 * Resolves with: `packages` (see callback)
 
+#### client.getPackagesWithFlags(serial, flags[, callback])
+
+Retrieves the list of packages present on the device. This is analogous to `adb shell pm list packages`. If you just want to see if something's installed, consider using `client.isInstalled()` instead.
+
+* **serial** The serial number of the device. Corresponds to the device ID in `client.listDevices()`.
+* **flags** Flags to pass to the `pm list packages` command to filter the list
+  ```
+  -d: filter to only show disabled packages
+  -e: filter to only show enabled packages
+  -s: filter to only show system packages
+  -3: filter to only show third party packages
+  ```
+* **callback(err, packages)** Optional. Use this or the returned `Promise`.
+    - **err** `null` when successful, `Error` otherwise.
+    - **packages** An array of package names.
+* Returns: `Promise`
+* Resolves with: `packages` (see callback)
+
 #### client.getProperties(serial[, callback])
 
 Retrieves the properties of the device identified by the given serial number. This is analogous to `adb shell getprop`.

--- a/lib/adb/client.ts
+++ b/lib/adb/client.ts
@@ -241,6 +241,14 @@ class Client extends EventEmitter {
 			.nodeify(callback);
 	}
 
+	public getPackagesWithFlags(serial: string, flags?: string, callback?: Callback<string[]>): Bluebird<string[]> {
+		return this.transport(serial)
+			.then(function (transport) {
+				return new GetPackagesCommand(transport).execute(flags);
+			})
+			.nodeify(callback);
+	}
+
 	public getDHCPIpAddress(
 		serial: string,
 		iface?: string | typeof callback,

--- a/lib/adb/client.ts
+++ b/lib/adb/client.ts
@@ -236,12 +236,12 @@ class Client extends EventEmitter {
 	public getPackages(serial: string, callback?: Callback<string[]>): Bluebird<string[]> {
 		return this.transport(serial)
 			.then(function (transport) {
-				return new GetPackagesCommand(transport).execute();
+				return new GetPackagesCommand(transport).execute(null);
 			})
 			.nodeify(callback);
 	}
 
-	public getPackagesWithFlags(serial: string, flags?: string, callback?: Callback<string[]>): Bluebird<string[]> {
+	public getPackagesWithFlags(serial: string, flags: string, callback?: Callback<string[]>): Bluebird<string[]> {
 		return this.transport(serial)
 			.then(function (transport) {
 				return new GetPackagesCommand(transport).execute(flags);

--- a/lib/adb/command/host-transport/getpackages.ts
+++ b/lib/adb/command/host-transport/getpackages.ts
@@ -5,8 +5,12 @@ import Bluebird from 'bluebird';
 const RE_PACKAGE = /^package:(.*?)\r?$/gm;
 
 class GetPackagesCommand extends Command<string[]> {
-	execute(): Bluebird<string[]> {
-		this._send('shell:pm list packages 2>/dev/null');
+	execute(flags = ''): Bluebird<string[]> {
+		if (flags !== '' && flags !== null) {
+			this._send('shell:pm list packages ' + flags + ' 2>/dev/null');
+		} else {
+			this._send('shell:pm list packages 2>/dev/null');
+		}
 		return this.parser.readAscii(4).then((reply) => {
 			switch (reply) {
 				case Protocol.OKAY:

--- a/lib/adb/command/host-transport/getpackages.ts
+++ b/lib/adb/command/host-transport/getpackages.ts
@@ -5,8 +5,8 @@ import Bluebird from 'bluebird';
 const RE_PACKAGE = /^package:(.*?)\r?$/gm;
 
 class GetPackagesCommand extends Command<string[]> {
-	execute(flags = ''): Bluebird<string[]> {
-		if (flags !== '' && flags !== null) {
+	execute(flags: string): Bluebird<string[]> {
+		if (flags) {
 			this._send('shell:pm list packages ' + flags + ' 2>/dev/null');
 		} else {
 			this._send('shell:pm list packages 2>/dev/null');

--- a/test/adb/command/host-transport/getpackages.js
+++ b/test/adb/command/host-transport/getpackages.js
@@ -32,6 +32,21 @@ describe('GetPackagesCommand', function() {
       return done();
     });
   });
+  it("should send 'pm list packages' with flag", function(done) {
+    var cmd, conn;
+    conn = new MockConnection();
+    cmd = new GetPackagesCommand(conn);
+    conn.socket.on('write', function(chunk) {
+      return expect(chunk.toString()).to.equal(Protocol.encodeData('shell:pm list packages -3 2>/dev/null').toString());
+    });
+    setImmediate(function() {
+      conn.socket.causeRead(Protocol.OKAY);
+      return conn.socket.causeEnd();
+    });
+    return cmd.execute('-3').then(function() {
+      return done();
+    });
+  });
   it("should return an empty array for an empty package list", function(done) {
     var cmd, conn;
     conn = new MockConnection();


### PR DESCRIPTION
As discussed in https://github.com/DeviceFarmer/adbkit/issues/55, this MR adds a parameter to the getPackages function that is passed to the `pm list packages` call.