### PR TITLE
Extend original `getPackages` method, keep compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,18 +396,7 @@ Retrieves the features of the device identified by the given serial number. This
 * Returns: `Promise`
 * Resolves with: `features` (see callback)
 
-#### client.getPackages(serial[, callback])
-
-Retrieves the list of packages present on the device. This is analogous to `adb shell pm list packages`. If you just want to see if something's installed, consider using `client.isInstalled()` instead.
-
-* **serial** The serial number of the device. Corresponds to the device ID in `client.listDevices()`.
-* **callback(err, packages)** Optional. Use this or the returned `Promise`.
-    - **err** `null` when successful, `Error` otherwise.
-    - **packages** An array of package names.
-* Returns: `Promise`
-* Resolves with: `packages` (see callback)
-
-#### client.getPackagesWithFlags(serial, flags[, callback])
+#### client.getPackages(serial[, flags]&#91;, callback])
 
 Retrieves the list of packages present on the device. This is analogous to `adb shell pm list packages`. If you just want to see if something's installed, consider using `client.isInstalled()` instead.
 
@@ -812,7 +801,7 @@ client.listDevices()
   .then(function(devices) {
     return Promise.map(devices, function(device) {
       return client.shell(device.id, 'logcat') // logcat just for illustration,
-                                               // prefer client.openLogcat in real use 
+                                               // prefer client.openLogcat in real use
         .then(function(conn) {
           var line = 0
           conn.on('data', function(data) {
@@ -821,8 +810,8 @@ client.listDevices()
             line += 1
             // close the stream and the running process
             // on the device will be gone, gracefully
-            if (line > 100) conn.end()
-          });
+            if (line > 100) conn.end()
+          })
           conn.on('close', function() {
             // here `ps` on the device shows the logcat process is gone
             console.log('100 lines read already, bye')

--- a/lib/adb/client.ts
+++ b/lib/adb/client.ts
@@ -112,24 +112,24 @@ class Client extends EventEmitter {
 	}
 
 	public connect(host: string, port: number | typeof callback = 5555, callback?: Callback<string>): Bluebird<string> {
-		let p: number;
+		let _port: number;
 		if (typeof port === 'function') {
 			callback = port;
-			p = 5555;
+			_port = 5555;
 		} else {
-			p = port;
+			_port = port;
 		}
 		if (host.indexOf(':') !== -1) {
 			const [h, portString] = host.split(':', 2);
 			host = h;
 			const parsed = parseInt(portString, 10);
 			if (!isNaN(parsed)) {
-				p = parsed;
+				_port = parsed;
 			}
 		}
 		return this.connection()
 			.then(function (conn) {
-				return new HostConnectCommand(conn).execute(host, p);
+				return new HostConnectCommand(conn).execute(host, _port);
 			})
 			.nodeify(callback);
 	}
@@ -139,24 +139,24 @@ class Client extends EventEmitter {
 		port: number | typeof callback = 5555,
 		callback?: Callback<string>,
 	): Bluebird<string> {
-		let p: number;
+		let _port: number;
 		if (typeof port === 'function') {
 			callback = port;
-			p = 5555;
+			_port = 5555;
 		} else {
-			p = port;
+			_port = port;
 		}
 		if (host.indexOf(':') !== -1) {
-			const [h, portString] = host.split(':', 2);
-			host = h;
+			const [_host, portString] = host.split(':', 2);
+			host = _host;
 			const parsed = parseInt(portString, 10);
 			if (!isNaN(parsed)) {
-				p = parsed;
+				_port = parsed;
 			}
 		}
 		return this.connection()
 			.then(function (conn) {
-				return new HostDisconnectCommand(conn).execute(host, p);
+				return new HostDisconnectCommand(conn).execute(host, _port);
 			})
 			.nodeify(callback);
 	}
@@ -238,16 +238,16 @@ class Client extends EventEmitter {
 		flags: string | typeof callback,
 		callback?: Callback<string[]>,
 	): Bluebird<string[]> {
-		let f: string;
+		let _flags: string;
 		if (typeof flags === 'function') {
 			callback = flags;
-			f = null;
+			_flags = null;
 		} else {
-			f = flags;
+			_flags = flags;
 		}
 		return this.transport(serial)
 			.then(function (transport) {
-				return new GetPackagesCommand(transport).execute(f);
+				return new GetPackagesCommand(transport).execute(_flags);
 			})
 			.nodeify(callback);
 	}
@@ -359,16 +359,16 @@ class Client extends EventEmitter {
 		format?: string | typeof callback,
 		callback?: Callback<FramebufferStreamWithMeta>,
 	): Bluebird<FramebufferStreamWithMeta> {
-		let f: string;
+		let _format: string;
 		if (typeof format === 'function') {
 			callback = format;
-			f = 'raw';
+			_format = 'raw';
 		} else {
-			f = format;
+			_format = format;
 		}
 		return this.transport(serial)
 			.then(function (transport) {
-				return new FrameBufferCommand(transport).execute(f);
+				return new FrameBufferCommand(transport).execute(_format);
 			})
 			.nodeify(callback);
 	}
@@ -406,15 +406,15 @@ class Client extends EventEmitter {
 		host?: string | typeof callback,
 		callback?: Callback<Duplex>,
 	): Bluebird<Duplex> {
-		let h: string | undefined;
+		let _host: string | undefined;
 		if (typeof host === 'function') {
 			callback = host;
 		} else {
-			h = host;
+			_host = host;
 		}
 		return this.transport(serial)
 			.then(function (transport) {
-				return new TcpCommand(transport).execute(port, h);
+				return new TcpCommand(transport).execute(port, _host);
 			})
 			.nodeify(callback);
 	}
@@ -424,15 +424,15 @@ class Client extends EventEmitter {
 		port: number | typeof callback = 1080,
 		callback?: Callback<Duplex>,
 	): Bluebird<Duplex> {
-		let p: number;
+		let _port: number;
 		if (typeof port === 'function') {
 			callback = port;
-			p = 1080;
+			_port = 1080;
 		} else {
-			p = port;
+			_port = port;
 		}
 		const tryConnect = (times) => {
-			return this.openTcp(serial, p)
+			return this.openTcp(serial, _port)
 				.then(function (stream) {
 					return Monkey.connectStream(stream);
 				})
@@ -451,7 +451,7 @@ class Client extends EventEmitter {
 			.catch(() => {
 				return this.transport(serial)
 					.then(function (transport) {
-						return new MonkeyCommand(transport).execute(p);
+						return new MonkeyCommand(transport).execute(_port);
 					})
 					.then(function (out) {
 						return tryConnect(20).then(function (monkey) {
@@ -469,16 +469,16 @@ class Client extends EventEmitter {
 		options?: { clear?: boolean } | typeof callback,
 		callback?: Callback<Logcat>,
 	): Bluebird<Logcat> {
-		let opts: { clear?: boolean };
+		let _options: { clear?: boolean };
 		if (typeof options === 'function') {
 			callback = options;
-			opts = {};
+			_options = {};
 		} else {
-			opts = options;
+			_options = options;
 		}
 		return this.transport(serial)
 			.then(function (transport) {
-				return new LogcatCommand(transport).execute(opts);
+				return new LogcatCommand(transport).execute(_options);
 			})
 			.then(function (stream) {
 				return Logcat.readStream(stream, {
@@ -638,15 +638,15 @@ class Client extends EventEmitter {
 		mode?: number | typeof callback,
 		callback?: Callback<PushTransfer>,
 	): Bluebird<PushTransfer> {
-		let m: number | undefined;
+		let _mode: number | undefined;
 		if (typeof mode === 'function') {
 			callback = mode;
 		} else {
-			m = mode;
+			_mode = mode;
 		}
 		return this.syncService(serial)
 			.then(function (sync) {
-				return sync.push(contents, path, m).on('end', function () {
+				return sync.push(contents, path, _mode).on('end', function () {
 					return sync.end();
 				});
 			})
@@ -654,16 +654,16 @@ class Client extends EventEmitter {
 	}
 
 	public tcpip(serial: string, port: number | typeof callback = 5555, callback?: Callback<number>): Bluebird<number> {
-		let p: number;
+		let _port: number;
 		if (typeof port === 'function') {
 			callback = port;
-			p = 5555;
+			_port = 5555;
 		} else {
-			p = port;
+			_port = port;
 		}
 		return this.transport(serial)
 			.then(function (transport) {
-				return new TcpIpCommand(transport).execute(p);
+				return new TcpIpCommand(transport).execute(_port);
 			})
 			.nodeify(callback);
 	}

--- a/lib/adb/client.ts
+++ b/lib/adb/client.ts
@@ -233,18 +233,21 @@ class Client extends EventEmitter {
 			.nodeify(callback);
 	}
 
-	public getPackages(serial: string, callback?: Callback<string[]>): Bluebird<string[]> {
+	public getPackages(
+		serial: string,
+		flags: string | typeof callback,
+		callback?: Callback<string[]>,
+	): Bluebird<string[]> {
+		let f: string;
+		if (typeof flags === 'function') {
+			callback = flags;
+			f = null;
+		} else {
+			f = flags;
+		}
 		return this.transport(serial)
 			.then(function (transport) {
-				return new GetPackagesCommand(transport).execute(null);
-			})
-			.nodeify(callback);
-	}
-
-	public getPackagesWithFlags(serial: string, flags: string, callback?: Callback<string[]>): Bluebird<string[]> {
-		return this.transport(serial)
-			.then(function (transport) {
-				return new GetPackagesCommand(transport).execute(flags);
+				return new GetPackagesCommand(transport).execute(f);
 			})
 			.nodeify(callback);
 	}


### PR DESCRIPTION
1. `getPackagesWithFlags` does not feel right
2. Library already has method with optional not last arguments (`connect`, `framebuffer`, `openTcp`, etc.)
3. It slipped my mind that we can do it this way, when I commented issue [here](https://github.com/DeviceFarmer/adbkit/pull/56#issuecomment-745516667)

refs #55 
@ov3rk1ll