### PR TITLE
Default to IPv4 localhost for Node 17 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Creates a client instance with the provided options. Note that this will not aut
 
 -   **options** An object compatible with [Net.connect][net-connect]'s options:
     -   **port** The port where the ADB server is listening. Defaults to `5037`.
-    -   **host** The host of the ADB server. Defaults to `'localhost'`.
+    -   **host** The host of the ADB server. Defaults to `'127.0.0.1'`.
     -   **bin** As the sole exception, this option provides the path to the `adb` binary, used for starting the server locally if initial connection fails. Defaults to `'adb'`.
 -   Returns: The client instance.
 

--- a/src/adb/client.ts
+++ b/src/adb/client.ts
@@ -21,14 +21,16 @@ import DeviceClient from './DeviceClient';
 
 export default class Client extends EventEmitter {
   public readonly options: ClientOptions;
+  public readonly host: string;
   public readonly port: number | string;
   public readonly bin: string;
 
-  constructor({ port = 5037, bin = 'adb' }: ClientOptions = { port: 5037 }) {
+  constructor({ host = '127.0.0.1', port = 5037, bin = 'adb' }: ClientOptions = { port: 5037 }) {
     super();
+    this.host = host;
     this.port = port;
     this.bin = bin;
-    this.options = { port, bin };
+    this.options = { host, port, bin };
   }
 
   public createTcpUsbBridge(serial: string, options: SocketOptions): TcpUsbServer {


### PR DESCRIPTION
Fix #209. Without this adbkit is not usable with Node 17 (or any other future Node versions, presumably).

When testing locally, on my machine with Node 17.0.1 the tests today fail with:

```
  1) Sync
       "before all" hook in "Sync":
     Error: connect ECONNREFUSED ::1:5037
      at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1161:16)
```

This happens because Node 17 defaults to IPv6 and ADB's local server _never_ listens for IPv6 connections, as far as I can tell.

This does change the default, which could affect anybody where localhost doesn't resolve to `127.0.0.1`, in theory, but in practice I don't think this will cause issues - anybody who resolves `localhost` to a different IP address has a very unusual configuration and likely has other networking issues already.

Interestingly, I had to add the `host` option from scratch for this PR, even though it's already documented as existing. I guess it got lost in the TypeScript rewrite? Pretty clear from the source that it didn't work until now.