### PR TITLE
Fixup TypeScript error for test

### DIFF
--- a/test/mock/duplex.ts
+++ b/test/mock/duplex.ts
@@ -23,7 +23,7 @@ export default class MockDuplex extends Stream.Duplex {
         this.push(null);
     }
 
-    end(...args: any[]): void {
+    end(...args: any[]): this {
         this.causeEnd(); // In order to better emulate socket streams
         return (Stream.Duplex.prototype.end as any).apply(this, args);
     }


### PR DESCRIPTION
One of the tests is failing in CI:

```
test/mock/duplex.ts:26:5 - error TS2416: Property 'end' in type 'MockDuplex' is not assignable to the same property in base type 'Duplex'.
```

This is breaking all the dependabot upgrades, namely https://github.com/DeviceFarmer/adbkit/pull/257 which includes a security fix.