### PR TITLE
Update commander

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 "@devicefarmer/adbkit-logcat": "^2.1.1",
 "@devicefarmer/adbkit-monkey": "~1.2.0",
 "bluebird": "~3.7",
-"commander": "^6.2.1",
+"commander": "^9.1.0",
 "debug": "~4.3.1",
 "node-forge": "^0.10.0",
 "split": "~1.0.1"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,11 +1,13 @@
 import fs from 'fs';
-import program from 'commander';
+import { Command } from 'commander';
 import forge from 'node-forge';
 import * as pkg from '../package.json';
 import Adb from './adb';
 import Auth from './adb/auth';
 import PacketReader from './adb/tcpusb/packetreader';
 import Bluebird from 'bluebird';
+
+const program = new Command();
 
 program.version(pkg.version);
 


### PR DESCRIPTION
Fixes up the updates in the Commander API to allow for updating to 9.1.0.

Superceeds the dependabot PR https://github.com/DeviceFarmer/adbkit/pull/262