### PR TITLE
Fix adb disconnect always throwing an error

### DIFF
--- a/src/adb/command/host/disconnect.ts
+++ b/src/adb/command/host/disconnect.ts
@@ -5,7 +5,10 @@ import Bluebird from 'bluebird';
 // Possible replies:
 // "No such device 192.168.2.2:5555"
 // ""
+// "disconnected 192.168.2.2:5555"
+
 const RE_OK = /^$/;
+const RE_DISC = /^disconnected.*$/
 
 export default class HostDisconnectCommand extends Command<string> {
   execute(host: string, port: number): Bluebird<string> {
@@ -14,7 +17,7 @@ export default class HostDisconnectCommand extends Command<string> {
       switch (reply) {
         case Protocol.OKAY:
           return this.parser.readValue().then(function (value) {
-            if (RE_OK.test(value.toString())) {
+            if (RE_OK.test(value.toString()) || RE_DISC.test(value.toString())) {
               return `${host}:${port}`;
             } else {
               throw new Error(value.toString());

--- a/test/adb/command/host/disconnect.ts
+++ b/test/adb/command/host/disconnect.ts
@@ -34,7 +34,7 @@ describe('DisconnectCommand', function () {
             expect(val).to.be.equal('192.168.2.2:5555');
         });
     });
-    return it('should reject with error if unable to disconnect', function () {
+    it('should reject with error if unable to disconnect', function () {
         const conn = new MockConnection();
         const cmd = new DisconnectCommand(conn as Connection);
         setImmediate(function () {
@@ -46,4 +46,16 @@ describe('DisconnectCommand', function () {
             expect(err.message).to.eql('No such device 192.168.2.2:5555');
         });
     });
+    return it('should resolve with the new device id if disconnected', function () {
+        const conn = new MockConnection();
+        const cmd = new DisconnectCommand(conn as Connection);
+        setImmediate(function () {
+            conn.getSocket().causeRead(Protocol.OKAY);
+            conn.getSocket().causeRead(Protocol.encodeData('disconnected 192.168.2.2:5555'));
+            return conn.getSocket().causeEnd();
+        });
+        return cmd.execute('192.168.2.2', 5555).then(function (val) {
+            expect(val).to.be.equal('192.168.2.2:5555');
+        });
+    });    
 });


### PR DESCRIPTION
This is an attempt to fix an exception on disconnect, although it successfully disconnects.

The reason is that "disconnected IP" is a possible value for successfull adb disconnects at least on Android11.
See Android 11 source:
https://cs.android.com/android/platform/superproject/+/android-11.0.0_r48:system/core/adb/adb.cpp;l=1224

Tested with an Nvidia Shield with Shield Experience 9.0.2 which is Android 11.