### PR TITLE
Add support for socket timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Creates a client instance with the provided options. Note that this will not aut
     -   **port** The port where the ADB server is listening. Defaults to `5037`.
     -   **host** The host of the ADB server. Defaults to `'127.0.0.1'`.
     -   **bin** As the sole exception, this option provides the path to the `adb` binary, used for starting the server locally if initial connection fails. Defaults to `'adb'`.
+    -   **timeout** The socket timeout in ms as defined by [Net.connect][net-connect]'s options. Defaults to `0` which means no timeout.
 -   Returns: The client instance.
 
 #### adb.util.parsePublicKey(androidKey)

--- a/src/adb.ts
+++ b/src/adb.ts
@@ -7,6 +7,7 @@ interface Options {
   host?: string;
   port?: number;
   bin?: string;
+  timeout?: number;
 }
 
 export default class Adb {
@@ -18,6 +19,7 @@ export default class Adb {
       bin: options.bin,
       host: options.host || process.env.ADB_HOST,
       port: options.port || 5037,
+      timeout: options.timeout || 0
     };
     if (!opts.port) {
       const port = parseInt(process.env.ADB_PORT || '5037', 10);

--- a/src/adb/client.ts
+++ b/src/adb/client.ts
@@ -24,13 +24,15 @@ export default class Client extends EventEmitter {
   public readonly host: string;
   public readonly port: number | string;
   public readonly bin: string;
+  public readonly timeout: number;
 
-  constructor({ host = '127.0.0.1', port = 5037, bin = 'adb' }: ClientOptions = { port: 5037 }) {
+  constructor({ host = '127.0.0.1', port = 5037, bin = 'adb', timeout = 0 }: ClientOptions = { port: 5037 }) {
     super();
     this.host = host;
     this.port = port;
     this.bin = bin;
-    this.options = { host, port, bin };
+    this.timeout = timeout;
+    this.options = { host, port, bin, timeout };
   }
 
   public createTcpUsbBridge(serial: string, options: SocketOptions): TcpUsbServer {


### PR DESCRIPTION
This adds support to create a client with a socket timeout.
This is necessary to workaround an incomplete implementation of adb cancellation in Android 11.
See: https://cs.android.com/android/platform/superproject/+/android-11.0.0_r48:frameworks/native/libs/adbd_auth/adbd_auth.cpp;l=230

If a user dismisses or cancels the adb auth dialog Android will not send any adb response to the client that wants to connect.
As a result waitForDevice() will stall forever.

With this change, you can specify a timeout of for example 30 seconds, so you can disconnect gracefully and try to reconnect.

This should probably be unittested, but I haven't found a good way to fake a socket timeout yet.