### PR TITLE
Fixed wrong extra flag for type float

### DIFF
--- a/src/adb/command/host-transport/startactivity.ts
+++ b/src/adb/command/host-transport/startactivity.ts
@@ -13,7 +13,7 @@ const EXTRA_TYPES = {
   bool: 'z',
   int: 'i',
   long: 'l',
-  float: 'l',
+  float: 'f',
   uri: 'u',
   component: 'cn',
 };


### PR DESCRIPTION
Using float extras is currently not possible because it wrongly shares its letter with the “long” type. Fixed that.