### PR TITLE
Install exception handling. Cleanup after install command.

### DIFF
--- a/src/adb/DeviceClient.ts
+++ b/src/adb/DeviceClient.ts
@@ -331,7 +331,7 @@ export default class DeviceClient {
 
      * @param port The port number to connect to.
      * @param host Optional. The host to connect to. Allegedly this is supposed to establish a connection to the given host from the device, but we have not been able to get it to work at all. Skip the host and everything works great.
-     * 
+     *
      * @returns The TCP connection (i.e. [`net.Socket`][node-net]). Read and write as you please. Call `conn.end()` to end the connection.
      */
   public openTcp(port: number, host?: string): Bluebird<Duplex> {
@@ -453,8 +453,9 @@ export default class DeviceClient {
     return this.transport().then((transport) => {
       return new InstallCommand(transport)
         .execute(apk)
-        .then(() => this.shell(['rm', '-f', apk]))
-        .then((stream) => new Parser(stream).readAll())
+        .finally(() => {
+          return this.shell(['rm', '-f', apk]).then((stream) => new Parser(stream).readAll());
+        })
         .then(() => true);
     });
   }
@@ -525,7 +526,7 @@ export default class DeviceClient {
      * Retrieves information about the given path.
      *
      * @param path The path.
-     * 
+     *
      * @returns An [`fs.Stats`][node-fs-stats] instance. While the `stats.is*` methods are available, only the following properties are supported:
         -   **mode** The raw mode.
         -   **size** The file size.

--- a/src/adb/command/host-transport/install.ts
+++ b/src/adb/command/host-transport/install.ts
@@ -2,6 +2,17 @@ import Protocol from '../../protocol';
 import Command from '../../command';
 import Bluebird from 'bluebird';
 
+const OKAY_OUTPUT_REGEXP = /^(Success|Failure \[(.*?)\]|Exception)(.*)$/;
+const INSTALL_EXCEPTION_CODE = 'INSTALL_EXCEPTION';
+
+class InstallError extends Error {
+  code: string;
+  constructor(message: string, code: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
 export default class InstallCommand extends Command<boolean> {
   execute(apk: string): Bluebird<boolean> {
     this._send(`shell:pm install -r ${this._escapeCompat(apk)}`);
@@ -9,21 +20,20 @@ export default class InstallCommand extends Command<boolean> {
       switch (reply) {
         case Protocol.OKAY:
           return this.parser
-            .searchLine(/^(Success|Failure \[(.*?)\])$/)
-            .then(function (match) {
-              let code, err;
+            .searchLine(OKAY_OUTPUT_REGEXP)
+            .then((match) => {
               if (match[1] === 'Success') {
                 return true;
+              } else if (match[1] === 'Exception') {
+                return this.parser.readLine().then((buffer: Buffer) => {
+                  throw new InstallError(buffer.toString(), INSTALL_EXCEPTION_CODE);
+                });
               } else {
-                code = match[2];
-                err = new Error(`${apk} could not be installed [${code}]`);
-                err.code = code;
-                throw err;
+                const code = match[2];
+                throw new InstallError(`${apk} could not be installed [${code}]`, code);
               }
             })
             .finally(() => {
-              // Consume all remaining content to "naturally" close the
-              // connection.
               return this.parser.readAll();
             });
         case Protocol.FAIL:


### PR DESCRIPTION

When installing an application on an android device, we use a package manager, giving it a command to install an application that is preloaded on the device.

**Problem:**

In response to the installation command, we expect to receive one of two Success or Failure statuses, in the case when the code "OKAY' is returned. However, there is a situation when the Exception status is returned, for example, if there is not enough memory on the device, in this case adbkit parses the response to the end, does not find a match and throws the error "prematureoferror", which cannot be called correct behavior. Throwing out this error confuses developers, as they think that the error is related to data transmission, while it is not.

**This behavior is demonstrated here #366.**

Also, when installing applications using the "remoteInstall" method, the temporary apk file was not always deleted, which again can lead to pm errors such as [this](https://github.com/appium/appium/issues/13888).

**Solution:**

Such errors can be easily calculated by the Exception keyword, and processed in the same way as Failure, in fact, this behavior was implemented.

Errors of this kind should also be handled by the developer of the android application, since they occur at the level of the android device and are in no way related to the STF system itself, therefore they should be communicated to the end user, which are Android developers.

To return malicious errors, a status has been added that does not overlap any of the existing package manager statuses: **INSTALL_EXCEPTION**.

Also, file deletion was added to finally to clean up the garbage after a successful or unsuccessful installation.

All possible error code can be find here:
https://github.com/aosp-mirror/platform_frameworks_base/blob/master/core/java/android/content/pm/PackageManager.java
### 
