### PR TITLE
Include 'unauthorized' in the possible device states type

### DIFF
--- a/src/Device.ts
+++ b/src/Device.ts
@@ -1,4 +1,4 @@
 export default interface Device {
   id: string;
-  type: 'emulator' | 'device' | 'offline';
+  type: 'emulator' | 'device' | 'offline' | 'unauthorized';
 }


### PR DESCRIPTION
Tiny types fix - this value is currently incorrectly excluded from the possible values here (which means checks like `device.type !== 'unauthorized'` are type errors).

This comes up whenever a device is connected but hasn't yet authorized debugging (e.g. the "Do you trust this computer" prompt is still open or was rejected). You can see examples in https://support.honeywellaidc.com/s/article/How-to-fix-adb-devices-shows-unauthorized-device and https://stackoverflow.com/a/25546300/68051.