### PR TITLE
Throw error if DELETE_FAILED_DEVICE_POLICY_MANAGER is sent

### DIFF
--- a/src/adb/command/host-transport/uninstall.ts
+++ b/src/adb/command/host-transport/uninstall.ts
@@ -2,6 +2,11 @@ import Protocol from '../../protocol';
 import Command from '../../command';
 import Bluebird from 'bluebird';
 
+class UninstallError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
 export default class UninstallCommand extends Command<boolean> {
   execute(pkg: string): Bluebird<boolean> {
     this._send(`shell:pm uninstall ${pkg}`);
@@ -13,6 +18,9 @@ export default class UninstallCommand extends Command<boolean> {
             .then(function (match) {
               if (match[1] === 'Success') {
                 return true;
+              } else if (match[1].includes('DELETE_FAILED_DEVICE_POLICY_MANAGER')) {
+                const reason = match[1];
+                throw new UninstallError(`${pkg} could not be uninstalled [${reason}]`);
               } else {
                 // Either way, the package was uninstalled or doesn't exist,
                 // which is good enough for us.

--- a/test/adb/command/host-transport/uninstall.ts
+++ b/test/adb/command/host-transport/uninstall.ts
@@ -33,6 +33,22 @@ describe('UninstallCommand', function () {
         });
         return cmd.execute('foo');
     });
+    it("should failed if command responds with 'Failure [DELETE_FAILED_DEVICE_POLICY_MANAGER]'", function (done) {
+        const conn = new MockConnection();
+        const cmd = new UninstallCommand(conn);
+        conn.getSocket().on('write', function (chunk) {
+            return expect(chunk.toString()).to.equal(Protocol.encodeData('shell:pm uninstall foo').toString());
+        });
+        setImmediate(function () {
+            conn.getSocket().causeRead(Protocol.OKAY);
+            conn.getSocket().causeRead('Failure [DELETE_FAILED_DEVICE_POLICY_MANAGER]\r\n');
+            return conn.getSocket().causeEnd();
+        });
+        cmd.execute('foo').catch(function (err) {
+            expect(err.message).includes('Failure [DELETE_FAILED_DEVICE_POLICY_MANAGER]');
+            done();
+        });
+    });
     it("should succeed even if command responds with 'Failure' with info in standard format", function () {
         const conn = new MockConnection();
         const cmd = new UninstallCommand(conn);


### PR DESCRIPTION
Hi, 
Some of our client's apk can not be installed due to  DELETE_FAILED_DEVICE_POLICY_MANAGER error of adb. In codebase returns true either way so we can't catch the apk is actually uninstalled.

This apk has device admin permission. If it is authorized then it can not be uninstalled regular way. First we must disable policy with "adb shell pm disable-user pkg" then uninstall it with normal way.

I share you an example apk has this permission:
https://apkcombo.com/device-administrator/io.ebeck.jacob.deviceadmin/download/apk

After the installation apk;
Open the app
Click the Enable Device Admin
It opens android permision pop-up
Click activate.

Then you could not uninstall the apk in normal way. It responds with "Failure [DELETE_FAILED_DEVICE_POLICY_MANAGER]"
So In the code i made some changes that throws an error if this event occurs. So in my workspace i can catch it then solved like above solution.

`import { Adb } from './src';

const client = Adb.createClient();

const udid = 'emulator-5554';
const element = 'io.ebeck.jacob.deviceadmin';
const device = client.getDevice(udid);

async function uninstall() {
  try {
    const result = await device.uninstall(element);
    console.log(result);
  } catch (error: any) {
    console.log(error.message);
    await device.shell("pm disable-user " + element)
      .then(Adb.util.readAll)
      .then((output) => {
        console.log('[%s] %s', device.serial, output.toString().trim());
      })
    const result = await device.uninstall(element);
    console.log(result);
  }
}

uninstall();
`

![image](https://github.com/DeviceFarmer/adbkit/assets/9132124/716e772b-ff93-43bd-898c-bcfc3afa7a76)

https://developer.android.com/reference/android/app/admin/DevicePolicyManager
https://stackoverflow.com/questions/13911444/disable-deviceadmin-from-shell
