### PR TITLE
Fix leaked promise in pull

### DIFF
--- a/src/adb/sync.ts
+++ b/src/adb/sync.ts
@@ -279,7 +279,7 @@ export default class Sync extends EventEmitter {
             return this.parser.readBytes(4).then((lengthData) => {
               const length = lengthData.readUInt32LE(0);
               return this.parser.readByteFlow(length, transfer).then(() => {
-                readNext();
+                return readNext()
               });
             });
           case Protocol.DONE:


### PR DESCRIPTION
When pulling, the second adb sync transfer was just ignored, causing a warning to be logged for every pull operation.

2024-09-11T20:10:52.421Z root ERROR (node:174306) Warning: a promise was created in a handler at node:internal/async_hooks:130:17 but was not returned from it, see http://goo.gl/rRqMUw
    at new Promise (/..../vendors-node_modules_drivelist_build_Release_drivelist_node-node_modules_devicefarmer_adbkit_-505406.js:50543:10)

Fixing this by actually returning the promise.