### PR TITLE
Based on adbkit v2.11.3 => it fixes a bug on stats using nodeJS 22.11.0 version and higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devicefarmer/adbkit",
-  "version": "2.11.3",
+  "version": "2.11.4",
   "description": "A pure Node.js client for the Android Debug Bridge.",
   "keywords": [
     "adb",

--- a/src/adb/sync/stats.coffee
+++ b/src/adb/sync/stats.coffee
@@ -21,6 +21,6 @@ class Stats extends Fs.Stats
   @S_IRGRP  = 0o0040   # group has read permission
 
   constructor: (@mode, @size, mtime) ->
-    @mtime = new Date mtime * 1000
+    @mtimeMs = new Date mtime * 1000
 
 module.exports = Stats


### PR DESCRIPTION
This PR targets `v2.11.3` tree and fixes a bug on stats when using NodeJS version `22.11.0` and higher:

- the `mtime` field of `Stats` Class in no more present, so it is replaced by the `mtimeMs` field using the same value of time 

I targeted the `master` branch because if I target the `v2.11.3` tag I am not able to submit the PR!

After this PR, I will submit another PR to fix the same bug in `master` branch so based this time on the latest code `v3.3.6+`