### PR TITLE
It fixes a bug on stats with nodeJS 22.11.0 version and higher

### DIFF
--- a/src/adb/sync/stats.ts
+++ b/src/adb/sync/stats.ts
@@ -43,6 +43,6 @@ export default class Stats extends Fs.Stats {
     this.mode = Number(mode);
     this.size = Number(sizeBig);
     this.sizeBig = sizeBig;
-    this.mtime = new Date(mtime * 1000);
+    this.mtimeMs = mtime * 1000;
   }
 }


### PR DESCRIPTION
This PR fixes a bug on stats when using NodeJS version `22.11.0` and higher:

- the `mtime` field of `Stats` Class is no more present, so it is replaced by the `mtimeMs` field. 