### PR TITLE
Allow authorization of known public keys in the tcp usb bridge

### DIFF
--- a/src/SocketOptions.ts
+++ b/src/SocketOptions.ts
@@ -3,4 +3,5 @@ import Bluebird from 'bluebird';
 
 export default interface SocketOptions {
   auth?: (key: ExtendedPublicKey) => Bluebird<void | boolean>;
+  knownPublicKeys?: ExtendedPublicKey[];
 }


### PR DESCRIPTION
Add an option to provide trusted public keys.
This prevents a "failed to authenticate" message from adb whenever you connect to a device