### PR TITLE
fix: fix memory leak after writing data with false result

### DIFF
--- a/src/adb/connection.ts
+++ b/src/adb/connection.ts
@@ -78,8 +78,9 @@ export default class Connection extends EventEmitter {
     return this;
   }
 
-  public write(data: Buffer, callback?: (err?: Error) => void): boolean {
-    return this.socket.write(dump(data), callback);
+  public write(data: Buffer, callback?: (err?: Error) => void): this {
+    this.socket.write(dump(data), callback);
+    return this;
   }
 
   public startServer(): Bluebird<ChildProcess> {

--- a/src/adb/connection.ts
+++ b/src/adb/connection.ts
@@ -78,9 +78,8 @@ export default class Connection extends EventEmitter {
     return this;
   }
 
-  public write(data: Buffer, callback?: (err?: Error) => void): this {
-    this.socket.write(dump(data), callback);
-    return this;
+  public write(data: Buffer, callback?: (err?: Error) => void): boolean {
+    return this.socket.write(dump(data), callback);
   }
 
   public startServer(): Bluebird<ChildProcess> {

--- a/src/adb/sync.ts
+++ b/src/adb/sync.ts
@@ -191,7 +191,7 @@ export default class Sync extends EventEmitter {
         if (!this.connection.socket.writableNeedDrain && (chunk = stream.read(DATA_MAX_LENGTH) || stream.read())) {
           this._sendCommandWithLength(Protocol.DATA, chunk.length);
           transfer.push(chunk.length);
-          if (this.connection.write(chunk, track)) {
+          if (!this.connection.write(chunk, track).socket.writableNeedDrain) {
             return writeNext();
           } else {
             return waitForDrain().then(writeNext);

--- a/src/adb/sync.ts
+++ b/src/adb/sync.ts
@@ -188,7 +188,7 @@ export default class Sync extends EventEmitter {
       const track = () => transfer.pop();
       const writeNext = () => {
         let chunk: Buffer;
-        if ((chunk = stream.read(DATA_MAX_LENGTH) || stream.read())) {
+        if (!this.connection.socket.writableNeedDrain && (chunk = stream.read(DATA_MAX_LENGTH) || stream.read())) {
           this._sendCommandWithLength(Protocol.DATA, chunk.length);
           transfer.push(chunk.length);
           if (this.connection.write(chunk, track)) {


### PR DESCRIPTION
There will be memory leak when sending big apk to Android device, because the `waitForDrain` will never be called.

https://github.com/DeviceFarmer/adbkit/blob/f458f6a9784b6f4f0e9e503d52864955d87181b8/src/adb/sync.ts#L194

```JavaScript
if (this.connection.write(chunk, track)) {
  return writeNext();
} else {
  return waitForDrain().then(writeNext);
}
```
The  `if (this.connection.write(chunk, track)) ` will always be true, 
https://github.com/DeviceFarmer/adbkit/blob/f458f6a9784b6f4f0e9e503d52864955d87181b8/src/adb/connection.ts#L81

```JavaScript
public write(data: Buffer, callback?: (err?: Error) => void): this {
    this.socket.write(dump(data), callback);
    return this;
 }
```
Nodejs AP reference:

https://nodejs.org/api/stream.html#writablewritechunk-encoding-callback

>callback will be called with the error as its first argument. The callback is called asynchronously and before 'error' is emitted.
The return value is true if the internal buffer is less than the highWaterMark configured when the stream was created after admitting chunk. If false is returned, further attempts to write data to the stream should stop until the ['drain'](https://nodejs.org/api/stream.html#event-drain) event is emitted.
While a stream is not draining, calls to write() will buffer chunk, and return false. Once all currently buffered chunks are drained (accepted for delivery by the operating system), the 'drain' event will be emitted. Once write() returns false, do not write more chunks until the 'drain' event is emitted. While calling write() on a stream that is not draining is allowed, Node.js will buffer all written chunks until maximum memory usage occurs, at which point it will abort unconditionally. Even before it aborts, high memory usage will cause poor garbage collector performance and high RSS (which is not typically released back to the system, even after the memory is no longer required). Since TCP sockets may never drain if the remote peer does not read the data, writing a socket that is not draining may lead to a remotely exploitable vulnerability.

