### PR TITLE
Fix bug that leaves dangling connections

### DIFF
--- a/src/adb/parser.ts
+++ b/src/adb/parser.ts
@@ -257,9 +257,17 @@ export default class Parser {
   }
 
   public readError(): Bluebird<never> {
-    return this.readValue().then(function (value) {
-      throw new Parser.FailError(value.toString());
-    });
+    return this.readValue()
+      .then(function (value) {
+        throw new Parser.FailError(value.toString());
+      })
+      .finally(() => {
+        // A FAIL ends the smart-socket conversation, but not all servers
+        // close the connection afterwards (e.g. adb 1.0.39 keeps it open
+        // after a failed host:transport), so we must destroy it ourselves
+        // to avoid leaking the socket.
+        this.stream.destroy();
+      });
   }
 
   public readValue(): Bluebird<Buffer> {
@@ -309,6 +317,9 @@ export default class Parser {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public unexpected(data: string, expected: string): Bluebird<any> {
+    // The protocol state is unknown after unexpected data, so the
+    // connection can never be safely reused; destroy it to avoid leaks.
+    this.stream.destroy();
     return Bluebird.reject(new Parser.UnexpectedDataError(data, expected));
   }
 }


### PR DESCRIPTION
Some old ADB servers (before r28.0.1) do not clean up connections after errors. These are more common that you'd think, as it seems they're bundled with various emulators.

In practice, this means that ADB connections can be left open indefinitely, easily resulting in scenarios where large numbers of sockets are used e.g. when polling.

This PR ensure we always kill connections after errors or invalid data - in both cases, the connection is always unusable regardless and is never reused today anyway.